### PR TITLE
add option to have a x offset from the right (-xr)

### DIFF
--- a/instantmenu.1
+++ b/instantmenu.1
@@ -66,6 +66,13 @@ If option
 .B \-m
 is present, the measurement will use the given monitor.
 .TP
+.BI \-xr " right xoffset"
+instantmenu is placed at this offset measured from the right side of the monitor.
+Can be negative.
+If option
+.B \-m
+is present, the measurement will use the given monitor.
+.TP
 .BI \-y " yoffset"
 instantmenu is placed at this offset measured from the top of the monitor.  If the
 .B \-b

--- a/instantmenu.c
+++ b/instantmenu.c
@@ -1518,7 +1518,7 @@ static void
 usage(void)
 {
 	fputs("usage: instantmenu [-bfinPv] [-l lines] [-p prompt] [-fn font] [-m monitor]\n"
-	      "             [-x xoffset] [-y yoffset] [-w width]\n"
+	      "             [-x xoffset] [-xr right x offset] [-y yoffset] [-w width]\n"
 	      "             [-h height]\n"
 
 	      "             [-nb color] [-nf color] [-sb color] [-sf color] [-w windowid]\n", stderr);

--- a/instantmenu.c
+++ b/instantmenu.c
@@ -1518,7 +1518,7 @@ static void
 usage(void)
 {
 	fputs("usage: instantmenu [-bfinPv] [-l lines] [-p prompt] [-fn font] [-m monitor]\n"
-	      "             [-x xoffset] [-xr right x offset] [-y yoffset] [-w width]\n"
+	      "             [-x xoffset] [-xr right xoffset] [-y yoffset] [-w width]\n"
 	      "             [-h height]\n"
 
 	      "             [-nb color] [-nf color] [-sb color] [-sf color] [-w windowid]\n", stderr);

--- a/instantmenu.c
+++ b/instantmenu.c
@@ -50,6 +50,7 @@ static char *embed;
 static int bh, mw, mh;
 static int dmx = 0, dmy = 0; /* put instantmenu at these x and y offsets */
 static int dmw = 0; /* make instantmenu this wide */
+static _Bool rightxoffset = False; /* make instantmenu x offset come from the right */
 static int inputw = 0, promptw, toast = 0, inputonly = 0, passwd = 0, nograb = 0, alttab = 0, tabbed = 0;
 static int lrpad; /* sum of left and right padding */
 static size_t cursor;
@@ -1419,9 +1420,9 @@ setup(void)
 		} else {
 			if (dmy <= -1)
 				dmy = drw->fonts->h * 1.55;
-			x = info[i].x_org + dmx;
-			y = info[i].y_org + (topbar ? dmy : info[i].height - mh - dmy);
 			mw = ((dmw>0 && dmw < info[i].width) ? dmw : info[i].width);
+			x = rightxoffset ? info[i].x_org + info[i].width - dmx - mw : info[i].x_org + dmx;
+			y = info[i].y_org + (topbar ? dmy : info[i].height - mh - dmy);
 		}
 
 		if (mh > drw->h - 10) {
@@ -1594,7 +1595,10 @@ main(int argc, char *argv[])
 			lines = atoi(argv[++i]);
 		else if (!strcmp(argv[i], "-x"))   /* window x offset */
 			dmx = atoi(argv[++i]);
-		else if (!strcmp(argv[i], "-y"))   /* window y offset (from bottom up if -b) */
+		else if (!strcmp(argv[i], "-xr")) {/* window x offset from the right */
+			rightxoffset = True;
+			dmx = atoi(argv[++i]);
+		} else if (!strcmp(argv[i], "-y"))   /* window y offset (from bottom up if -b) */
 			dmy = atoi(argv[++i]);
 		else if (!strcmp(argv[i], "-w"))   /* make instantmenu this wide */
 			dmw = atoi(argv[++i]);

--- a/instantmenu.c
+++ b/instantmenu.c
@@ -50,7 +50,7 @@ static char *embed;
 static int bh, mw, mh;
 static int dmx = 0, dmy = 0; /* put instantmenu at these x and y offsets */
 static int dmw = 0; /* make instantmenu this wide */
-static _Bool rightxoffset = False; /* make instantmenu x offset come from the right */
+static int rightxoffset = 0; /* make instantmenu x offset come from the right */
 static int inputw = 0, promptw, toast = 0, inputonly = 0, passwd = 0, nograb = 0, alttab = 0, tabbed = 0;
 static int lrpad; /* sum of left and right padding */
 static size_t cursor;
@@ -1421,7 +1421,7 @@ setup(void)
 			if (dmy <= -1)
 				dmy = drw->fonts->h * 1.55;
 			mw = ((dmw>0 && dmw < info[i].width) ? dmw : info[i].width);
-			x = rightxoffset ? info[i].x_org + info[i].width - dmx - mw : info[i].x_org + dmx;
+			x = rightxoffset ? info[i].x_org + info[i].width - dmx - mw - 2 * border_width : info[i].x_org + dmx;
 			y = info[i].y_org + (topbar ? dmy : info[i].height - mh - dmy);
 		}
 
@@ -1596,7 +1596,7 @@ main(int argc, char *argv[])
 		else if (!strcmp(argv[i], "-x"))   /* window x offset */
 			dmx = atoi(argv[++i]);
 		else if (!strcmp(argv[i], "-xr")) {/* window x offset from the right */
-			rightxoffset = True;
+			rightxoffset = 1;
 			dmx = atoi(argv[++i]);
 		} else if (!strcmp(argv[i], "-y"))   /* window y offset (from bottom up if -b) */
 			dmy = atoi(argv[++i]);


### PR DESCRIPTION
`-xr number` does the same thing for x that `-b -y number` does for y.

A few notes:
It is only one option (unlike `-b` and `-y`) because the behavior with the x offset coming from the right is the same as normal, whereas  `-b` can be used on its own.
The variable name `rightxoffset` can be changed to fit with other variables, I couldn't come up with anything else.
xr could stand for either x right or x reverse.