### PR TITLE
add reject no match option

### DIFF
--- a/instantmenu.1
+++ b/instantmenu.1
@@ -3,7 +3,7 @@
 instantMENU \- menu for instantOS
 .SH SYNOPSIS
 .B instantmenu
-.RB [ \-bfivP ]
+.RB [ \-bfirvP ]
 .RB [ \-l
 .IR lines ]
 .RB [ \-g
@@ -68,6 +68,9 @@ Disable fuzzy matching
 .TP
 .B \-A
 Enable alt-tab behaviour
+.TP
+.B \-r
+instantmenu rejects input that does not result in a match
 .TP
 .B \-it " initialtext"
 instantmenu starts with an initial text in the input field

--- a/instantmenu.c
+++ b/instantmenu.c
@@ -1028,7 +1028,7 @@ insert:
 			break;
 		animatesel();
 
-		puts((sel && !(ev->state & ShiftMask & !(rejectnomatch))) ? sel->text : text);
+		puts((sel && !(ev->state & ShiftMask & (!rejectnomatch))) ? sel->text : text);
 		if (!(ev->state & ControlMask)) {
 			cleanup();
 			exit(0);

--- a/instantmenu.c
+++ b/instantmenu.c
@@ -1028,7 +1028,7 @@ insert:
 			break;
 		animatesel();
 
-		puts((sel && !(ev->state & ShiftMask & !rejectnomatch)) ? sel->text : text);
+		puts((sel && !(ev->state & ShiftMask & !(rejectnomatch))) ? sel->text : text);
 		if (!(ev->state & ControlMask)) {
 			cleanup();
 			exit(0);


### PR DESCRIPTION
This adds an option (-r) that rejects input if it would result no matches
occurring. Would be useful for menus like the settings menu and the
display menu as there is no point in allowing more input in a menu that requires
specific input.

* Ported from https://tools.suckless.org/dmenu/patches/reject-no-match/