### PR TITLE
some fixes for grid

### DIFF
--- a/config.def.h
+++ b/config.def.h
@@ -45,7 +45,7 @@ static const char *colors[SchemeLast][9] = {
 /* -l option; if nonzero, instantmenu uses vertical list with given number of lines */
 /* -g option; controls columns in grid if nonzero and lines is nonzero */
 static unsigned int lines      = 0;
-static unsigned int columns    = 0;
+static unsigned int columns    = 1;
 
 /*
  * Characters not considered part of a word while deleting words

--- a/instantmenu.c
+++ b/instantmenu.c
@@ -1891,7 +1891,7 @@ main(int argc, char *argv[])
 	}
 
 	if (dmw <= -1) {
-		int maxw = max_textw() * 1.3 + (prompt ? TEXTW(prompt) : 0);
+		int maxw = max_textw() * 1.3 * MAX(columns, 1) + (prompt ? TEXTW(prompt) : 0);
 		if (dmw * (-1) > maxw) {
 			dmw = dmw * (-1);
 		} else {

--- a/instantmenu.c
+++ b/instantmenu.c
@@ -1362,7 +1362,8 @@ readstdin(void)
 	if (items)
 		items[i].text = NULL;
 	inputw = items ? TEXTW(items[imax].text) : 0;
-	lines = MIN(lines, i);
+	lines = MIN(lines, i / columns + (i % columns != 0));
+	columns = MIN(lines ? i / lines + (i % lines != 0) : columns, i);
 }
 
 static void
@@ -1782,10 +1783,9 @@ main(int argc, char *argv[])
 		else if (!strcmp(argv[i], "-g")) {   /* number of columns in grid */
 			columns = atoi(argv[++i]);
 			if (lines == 0) lines = 1;
-		} else if (!strcmp(argv[i], "-l")) { /* number of lines in vertical list */
+		} else if (!strcmp(argv[i], "-l"))   /* number of lines in vertical list */
 			lines = atoi(argv[++i]);
-			if (columns == 0) columns = 1;
-		} else if (!strcmp(argv[i], "-x"))   /* window x offset */
+		else if (!strcmp(argv[i], "-x"))   /* window x offset */
 			dmx = atoi(argv[++i]);
         else if (!strcmp(argv[i], "-xr")) {
             rightxoffset = 1;

--- a/instantmenu.c
+++ b/instantmenu.c
@@ -1363,7 +1363,8 @@ readstdin(void)
 		items[i].text = NULL;
 	inputw = items ? TEXTW(items[imax].text) : 0;
 	lines = MIN(lines, i / columns + (i % columns != 0));
-	columns = MIN(lines ? i / lines + (i % lines != 0) : columns, i);
+	if (!(columns == 1))
+		columns = MIN(lines ? i / lines + (i % lines != 0) : columns, i);
 }
 
 static void


### PR DESCRIPTION
just some min/max checks when using negative numbers

examples of what was broken:
- `echo $'a\nb' | instantmenu -g 3`
- `echo $'a\nb\nc' | instantmenu -g 2 -l -1`
- `echo $'a\nb\nc' | instantmenu -g 2 -l 2 -w -1`